### PR TITLE
#6 - Python3.11 tests failing due to TypeError: "quotechar" must be a…

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -777,7 +777,6 @@ class Writer(object):
             stream,
             delimiter="\t",
             lineterminator=lineterminator,
-            quotechar="",
             quoting=csv.QUOTE_NONE,
         )
         self.template = template


### PR DESCRIPTION
Fix for #6 -  Test failing with python 3.11

quotechar is unused when ```quoting=csv.QUOTE_NONE``` is used